### PR TITLE
add flag to enable Play Feature Delivery

### DIFF
--- a/install-aab
+++ b/install-aab
@@ -154,7 +154,7 @@ if [[ ! -z "${DEVICE_ID}" ]]; then
     DEVICE_INFO="--device-id ${DEVICE_ID}"
 fi
 
-bundletool "build-apks" "--connected-device" $DEVICE_INFO "--overwrite" "--bundle=${AAB_FILE}" "--output=${TEMP_PATH}" $KEY_INFO
+bundletool "build-apks --local-testing" "--connected-device" $DEVICE_INFO "--overwrite" "--bundle=${AAB_FILE}" "--output=${TEMP_PATH}" $KEY_INFO
 
 echo "Installing APK"
 bundletool "install-apks" "--apks=${TEMP_PATH}" $DEVICE_INFO

--- a/install-aab
+++ b/install-aab
@@ -154,7 +154,7 @@ if [[ ! -z "${DEVICE_ID}" ]]; then
     DEVICE_INFO="--device-id ${DEVICE_ID}"
 fi
 
-bundletool "build-apks --local-testing" "--connected-device" $DEVICE_INFO "--overwrite" "--bundle=${AAB_FILE}" "--output=${TEMP_PATH}" $KEY_INFO
+bundletool "build-apks" "--local-testing" "--connected-device" $DEVICE_INFO "--overwrite" "--bundle=${AAB_FILE}" "--output=${TEMP_PATH}" $KEY_INFO
 
 echo "Installing APK"
 bundletool "install-apks" "--apks=${TEMP_PATH}" $DEVICE_INFO


### PR DESCRIPTION
hi,
i would like to propose a change to add the flag `--local-testing` as this enables us to test with dynamic delivery features

FYI quote from google doc https://developer.android.com/guide/playcore/feature-delivery/on-demand#build-apks regarding this flag
```
The --local-testing flag includes meta-data in your APKs' manifests that lets the Play Feature Delivery Library know to use the local split APKs to test installing feature modules, without connecting to the Play Store.
```