### PR TITLE
[Feature] Pass forward APK build flags

### DIFF
--- a/install-aab
+++ b/install-aab
@@ -10,6 +10,7 @@ KEYSTORE_PASSWORD=""
 ALIAS=""
 ALIAS_PASSWORD=""
 DEVICE_ID=""
+BUILD_FLAGS=""
 
 function print_help {
     echo "Usage:"
@@ -23,6 +24,7 @@ function print_help {
     echo "    --alias-password -ap: Alias password (optional)"
     echo "    --help           -h : Prints this helper message"
     echo "    --device-id         : Id of the device where the APK will be installed (optional)"
+    echo "    --local-testing     : Pass forward the --local-testing flag to bundletool while building the apks (optional)"
     echo ""
     echo "Keystore:"
     echo "    If all the key configuration is passed, the provided keystore will be used to sign the application. Otherwise, debug keystore is used."
@@ -31,12 +33,13 @@ function print_help {
 
 function print_environment {
     echo "Environment:"
-    echo "  AAB path  : ${AAB_FILE}"
-    echo "  Java      : ${JAVA_HOME}"
-    echo "  adb       : $(which adb)"
-    echo "  bundletool: $(which bundletool)"
-    echo "  keystore  : ${KEYSTORE_FILE}"
-    echo "  device id : ${DEVICE_ID}"
+    echo "  AAB path    : ${AAB_FILE}"
+    echo "  Java        : ${JAVA_HOME}"
+    echo "  adb         : $(which adb)"
+    echo "  bundletool  : $(which bundletool)"
+    echo "  keystore    : ${KEYSTORE_FILE}"
+    echo "  device id   : ${DEVICE_ID}"
+    echo "  build flags : ${BUILD_FLAGS}"
 }
 
 function command_exists {
@@ -108,6 +111,7 @@ while [ -n "$1" ]; do
         --alias | -a) ALIAS="$2" && shift ;;
         --alias-password | -ap) ALIAS_PASSWORD="$2"  && shift ;;
         --device-id) DEVICE_ID="$2" && shift ;;
+        *) BUILD_FLAGS="${BUILD_FLAGS} $1" ;;
     esac
     shift
 done
@@ -134,6 +138,9 @@ if ! command_exists java; then
     install_java
 fi
 
+#Trim build flags command
+BUILD_FLAGS="$(echo "${BUILD_FLAGS//.}")"
+
 validate_keyconfig
 print_environment
 
@@ -154,10 +161,13 @@ if [[ ! -z "${DEVICE_ID}" ]]; then
     DEVICE_INFO="--device-id ${DEVICE_ID}"
 fi
 
-bundletool "build-apks" "--connected-device" $DEVICE_INFO "--overwrite" "--bundle=${AAB_FILE}" "--output=${TEMP_PATH}" $KEY_INFO
+BUILD_COMMAND="bundletool build-apks ${BUILD_FLAGS} --connected-device $DEVICE_INFO --overwrite --bundle=${AAB_FILE} --output=${TEMP_PATH} $KEY_INFO"
+echo "Running ${BUILD_COMMAND}"
+eval "${BUILD_COMMAND}"
 
-echo "Installing APK"
-bundletool "install-apks" "--apks=${TEMP_PATH}" $DEVICE_INFO
+INSTALL_COMMAND="bundletool install-apks --apks=${TEMP_PATH} $DEVICE_INFO"
+echo "Running ${INSTALL_COMMAND}"
+eval "${INSTALL_COMMAND}"
 
 if [[ -f "${TEMP_PATH}" ]]; then
     rm "${TEMP_PATH}"


### PR DESCRIPTION
### Task

Allow the user of the command to pass additional build flags into bundletool

### Implementation

1. Understand any not-defined flag as an extra build flag
2. Pass the custom set of flags into the build-apks command
3. Improve logging